### PR TITLE
Assign new shadow root to root variable in getSelectedText function.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sequence-viewer",
   "description": "A protein sequence viewer written in javascript",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "homepage": "https://github.com/calipho-sib/sequence-viewer",
   "authors": [
     "Mathieu Schaeffer <mat.schaeff@gmail.com>",

--- a/src/sequence-viewer.js
+++ b/src/sequence-viewer.js
@@ -233,7 +233,7 @@ var Sequence = (function () {
       }
 
       seqInit = $(divId + " .fastaSeq").html();
-      mouseSelectionListener();
+      mouseSelectionListener(document);
     };
 
     this.selection = function (start, end, color, options) {
@@ -615,9 +615,9 @@ var Sequence = (function () {
         self.trigger(self.events.SEQUENCE_SELECTED_EVENT, selection);
     }
 
-    function mouseSelectionListener() {
+    function mouseSelectionListener(document) {
       $(divID + " .fastaSeq").mouseup(function () {
-        var selectedSubpart = getSelectedText();
+        var selectedSubpart = getSelectedText(document);
         if (selectedSubpart) {
           triggerMouseSelectionEvent(selectedSubpart);
           if (sequenceOptions.blast) {
@@ -645,7 +645,8 @@ var Sequence = (function () {
       //$(document).on(self.events.FEATURE_SELECTED_EVENT, listener);
     };
 
-    function getSelectedText() {
+    function getSelectedText(document) {
+      root = document;
       var text = window.getSelection().toString().replace(/\s+/g, "");
       var selection = root.getSelection();
       var element = $(divID + " .fastaSeq")[0];


### PR DESCRIPTION
## Description

Assign new shadow root to root variable in getSelectedText function. This fixes the problem with mouseSelection event when there are multiple sequence-viewer in the same page.